### PR TITLE
Initial CI/CD

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -3,3 +3,4 @@ major_version_zero = true
 version_provider = "cargo"
 version_scheme = "semver2"
 update_changelog_on_bump = true
+tag_format = "v$version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Check PR code quality
 
 on:
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+      FORCE_COLOR: 1
+    steps:
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.14
+      - uses: actions/checkout@v4
+      - name: Check code quality
+        run: earthly --org nu_plugin_vec --ci +check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Check PR code quality
+name: Check code quality
 
 on:
   pull_request:
@@ -16,4 +16,4 @@ jobs:
           version: v0.8.14
       - uses: actions/checkout@v4
       - name: Check code quality
-        run: earthly --org nu_plugin_vec --ci +check
+        run: earthly --ci +check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+      FORCE_COLOR: 1
+    steps:
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.14
+      - uses: actions/checkout@v4
+      - name: Build and release
+        run: earthly --org nu_plugin_vec --ci +release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
     env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
       FORCE_COLOR: 1
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  bumpVersion:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -17,4 +18,19 @@ jobs:
           version: v0.8.14
       - uses: actions/checkout@v4
       - name: Build and release
-        run: earthly --org nu_plugin_vec --ci +release
+        run: earthly --ci --push +bumpVersion
+
+  release:
+    if: "startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+      FORCE_COLOR: 1
+    steps:
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.14
+      - uses: actions/checkout@v4
+      - name: Build and release
+        run: earthly --ci --push +release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Dennis Kottier <me@photonbur.st>"]
+authors = ["Dennis Kottier <inquiries@photonbur.st>"]
 description = "A Nushell plugin implementing vector operations"
 edition = "2021"
 homepage = "https://github.com/FMotalleb/nu_plugin_desktop_notifications"

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,5 @@
 VERSION 0.8
+PROJECT nu_plugin_vec/plugin
 
 IMPORT github.com/earthly/lib/rust:2.2.11 AS rust
 

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,48 @@
+VERSION --global-cache 0.7
+
+IMPORT github.com/earthly/lib/rust:2.2.11 AS rust
+
+install:
+  FROM rust:1.81.0-bookworm
+  RUN rustup component add clippy rustfmt
+
+  # Call +INIT before copying the source file to avoid installing function depencies every time source code changes
+  # This parametrization will be used in future calls to functions of the library
+  DO rust+INIT --keep_fingerprints=true
+
+source:
+  FROM +install
+  COPY --keep-ts Cargo.toml Cargo.lock ./
+  COPY --keep-ts --dir src ./
+
+# lint runs cargo clippy on the source code
+lint:
+  FROM +source
+  DO rust+CARGO --args="clippy --all-features --all-targets -- -D warnings"
+
+# build builds with the Cargo release profile
+build:
+  FROM +lint
+  DO rust+CARGO --args="build --release" --output="release/[^/\.]+"
+  SAVE ARTIFACT ./target/release/ target AS LOCAL artifact/target
+
+# test executes all unit and integration tests via Cargo
+test:
+  FROM +lint
+  DO rust+CARGO --args="test"
+
+# fmt checks whether Rust code is formatted according to style guidelines
+fmt:
+  FROM +lint
+  DO rust+CARGO --args="fmt --check"
+
+# all runs all other targets in parallel
+check:
+  BUILD +build
+  BUILD +test
+  BUILD +fmt
+
+release:
+  FROM +build
+  DO rust+CARGO --args="login"
+  DO rust+CARGO --args="publish"

--- a/Earthfile
+++ b/Earthfile
@@ -12,28 +12,33 @@ install:
 
 source:
   FROM +install
-  COPY --keep-ts Cargo.toml Cargo.lock ./
-  COPY --keep-ts --dir src ./
+  WORKDIR /build
+
+  DO +COPY_SOURCE
 
 # lint runs cargo clippy on the source code
 lint:
   FROM +source
+
   DO rust+CARGO --args="clippy --all-features --all-targets -- -D warnings"
 
 # build builds with the Cargo release profile
 build:
   FROM +lint
+
   DO rust+CARGO --args="build --release" --output="release/[^/\.]+"
   SAVE ARTIFACT ./target/release/ target AS LOCAL artifact/target
 
 # test executes all unit and integration tests via Cargo
 test:
   FROM +lint
+
   DO rust+CARGO --args="test"
 
 # fmt checks whether Rust code is formatted according to style guidelines
 fmt:
   FROM +lint
+
   DO rust+CARGO --args="fmt --check"
 
 # all runs all other targets in parallel
@@ -41,7 +46,59 @@ check:
   BUILD +test
   BUILD +fmt
 
+# bumps the version of the plugin if impactful commits have been made
+bumpVersion:
+  ARG COMMITTER_NAME
+  ARG COMMITTER_EMAIL
+
+  FROM commitizen/commitizen:3.29.0
+  WORKDIR /build
+
+  # Check whether the repository is in a good state to push
+  DO +COPY_SOURCE
+  BUILD +check
+
+  # Conservatively copy other files needed for next steps
+  DO +COPY_GIT
+  DO +COPY_CZ
+  # Test whether a version bump is necessary
+  IF cz bump --dry-run
+    # Copy all files in the git repo, as cz bump does a git commit
+    # (and we don't want to delete things from the repository)
+    DO +COPY_ALL
+
+    # Bump the version, and push this change to the repository
+    RUN cz bump
+    RUN --push git push
+  END
+
+# releases the plugin to crates.io
 release:
-  FROM +build
-  DO rust+CARGO --args="login"
-  DO rust+CARGO --args="publish"
+    FROM +build
+
+    DO rust+CARGO --args="login" # Uses the CARGO_REGISTRY_TOKEN env var to log in
+    DO rust+CARGO --args="publish"
+
+
+
+COPY_ALL:
+  FUNCTION
+
+  COPY --keep-ts * ./
+  COPY --keep-ts --dir * ./
+
+COPY_CZ:
+  FUNCTION
+
+  COPY --keep-ts .cz.toml ./
+
+COPY_GIT:
+  FUNCTION
+
+  COPY --keep-ts --dir .git ./
+
+COPY_SOURCE:
+  FUNCTION
+
+  COPY --keep-ts Cargo.toml Cargo.lock ./
+  COPY --keep-ts --dir src ./

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-VERSION --global-cache 0.7
+VERSION --global-cache 0.8
 
 IMPORT github.com/earthly/lib/rust:2.2.11 AS rust
 

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-VERSION --global-cache 0.8
+VERSION 0.8
 
 IMPORT github.com/earthly/lib/rust:2.2.11 AS rust
 

--- a/Earthfile
+++ b/Earthfile
@@ -38,7 +38,6 @@ fmt:
 
 # all runs all other targets in parallel
 check:
-  BUILD +build
   BUILD +test
   BUILD +fmt
 

--- a/src/commands/cos.rs
+++ b/src/commands/cos.rs
@@ -111,7 +111,7 @@ pub fn compute_vcos(
 
     let output = dot_product.div(command_span, &magnitude_product, command_span);
 
-    output.map_err(|err| LabeledError::from(err))
+    output.map_err(LabeledError::from)
 }
 
 #[cfg(test)]

--- a/src/commands/dot.rs
+++ b/src/commands/dot.rs
@@ -8,8 +8,8 @@ use nu_plugin_test_support::PluginTest;
 #[cfg(test)]
 use nu_protocol::ShellError;
 use nu_protocol::{
-    Category, Example, IntoValue, LabeledError, PipelineData, Signature, Span,
-    SyntaxShape, Type, Value,
+    Category, Example, IntoValue, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type,
+    Value,
 };
 
 struct Arguments {

--- a/src/commands/magnitude.rs
+++ b/src/commands/magnitude.rs
@@ -7,8 +7,7 @@ use nu_plugin_test_support::PluginTest;
 #[cfg(test)]
 use nu_protocol::ShellError;
 use nu_protocol::{
-    Category, Example, IntoValue, LabeledError, PipelineData, Signature, Span, Type,
-    Value,
+    Category, Example, IntoValue, LabeledError, PipelineData, Signature, Span, Type, Value,
 };
 
 #[derive(Clone)]
@@ -71,7 +70,7 @@ pub fn compute_magnitude(vector: &[Value], command_span: Span) -> Result<Value, 
         .coerce_float()
         .map(|float| float.sqrt().into_value(command_span));
 
-    output.map_err(|err| LabeledError::from(err))
+    output.map_err(LabeledError::from)
 }
 
 #[cfg(test)]

--- a/src/commands/sin.rs
+++ b/src/commands/sin.rs
@@ -5,7 +5,10 @@ use itertools::Itertools;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 #[cfg(test)]
 use nu_plugin_test_support::PluginTest;
-use nu_protocol::{Category, Example, IntoValue, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value};
+use nu_protocol::{
+    Category, Example, IntoValue, LabeledError, PipelineData, ShellError, Signature, Span,
+    SyntaxShape, Type, Value,
+};
 
 struct Arguments {
     vector_rhs: Vec<f64>,
@@ -103,7 +106,7 @@ pub fn compute_vsin(
         .coerce_float()
         .map(|float| float.sqrt().into_value(command_span));
 
-    output.map_err(|err| LabeledError::from(err))
+    output.map_err(LabeledError::from)
 }
 
 #[cfg(test)]

--- a/src/commands/sqnorm.rs
+++ b/src/commands/sqnorm.rs
@@ -6,9 +6,7 @@ use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_plugin_test_support::PluginTest;
 #[cfg(test)]
 use nu_protocol::ShellError;
-use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, Signature, Span, Type, Value,
-};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Span, Type, Value};
 
 #[derive(Clone)]
 pub struct Command;
@@ -50,10 +48,7 @@ impl PluginCommand for Command {
         call: &EvaluatedCall,
         input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
-        match operate(call, input) {
-            Ok(val) => Ok(val),
-            Err(err) => Err(LabeledError::from(err)),
-        }
+        operate(call, input)
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,11 +9,8 @@ pub fn process_pipeline(
     mf: impl Fn(&[Value], Span, Span) -> Result<Value, LabeledError>,
 ) -> Result<PipelineData, LabeledError> {
     let name = call.head;
-    let res = calculate(input, name, mf);
-    match res {
-        Ok(v) => Ok(v.into_pipeline_data()),
-        Err(e) => Err(LabeledError::from(e)),
-    }
+
+    calculate(input, name, mf).map(|v| v.into_pipeline_data())
 }
 
 pub fn calculate(
@@ -23,9 +20,7 @@ pub fn calculate(
 ) -> Result<Value, LabeledError> {
     let span = values.span().unwrap_or(name);
     match values {
-        PipelineData::Value(Value::List { ref vals, .. }, ..) => match &vals[..] {
-            _ => mf(vals, span, name),
-        },
+        PipelineData::Value(Value::List { ref vals, .. }, ..) => mf(vals, span, name),
         PipelineData::Empty { .. } => Err(LabeledError::from(ShellError::PipelineEmpty {
             dst_span: name,
         })),


### PR DESCRIPTION
This closes #2, introducing initial CI/CD to the repo.

It uses Earthly for the flow of the pipeline, integrating with Cargo for releases and commitizen for version management based on commit messages.