### PR TITLE
Fix commitizen not picking up on tags in the repository

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -41,6 +41,7 @@ fmt:
   FROM +lint
 
   # DEBUG which tags are available?
+  COPY --keep-ts --dir .git ./
   RUN git tag --list
 
   DO rust+CARGO --args="fmt --check"

--- a/Earthfile
+++ b/Earthfile
@@ -21,6 +21,11 @@ source:
 lint:
   FROM +source
 
+  # DEBUG which tags are available?
+  DO +COPY_GIT
+  RUN cz bump --dry-run
+  RUN exit 0
+
   DO rust+CARGO --args="clippy --all-features --all-targets -- -D warnings"
 
 # build builds with the Cargo release profile
@@ -39,10 +44,6 @@ test:
 # fmt checks whether Rust code is formatted according to style guidelines
 fmt:
   FROM +lint
-
-  # DEBUG which tags are available?
-  COPY --keep-ts --dir .git ./
-  RUN git tag --list
 
   DO rust+CARGO --args="fmt --check"
 

--- a/Earthfile
+++ b/Earthfile
@@ -21,11 +21,6 @@ source:
 lint:
   FROM +source
 
-  # DEBUG which tags are available?
-  DO +COPY_GIT
-  RUN cz bump --dry-run
-  RUN exit 0
-
   DO rust+CARGO --args="clippy --all-features --all-targets -- -D warnings"
 
 # build builds with the Cargo release profile

--- a/Earthfile
+++ b/Earthfile
@@ -99,6 +99,7 @@ COPY_GIT:
   FUNCTION
 
   COPY --keep-ts --dir .git ./
+  RUN git pull --tags
 
 COPY_SOURCE:
   FUNCTION

--- a/Earthfile
+++ b/Earthfile
@@ -40,15 +40,15 @@ test:
 fmt:
   FROM +lint
 
+  # DEBUG which tags are available?
+  RUN git tag --list
+
   DO rust+CARGO --args="fmt --check"
 
 # all runs all other targets in parallel
 check:
   BUILD +test
   BUILD +fmt
-
-  # DEBUG which tags are available?
-  RUN git tag --list
 
 # bumps the version of the plugin if impactful commits have been made
 bumpVersion:

--- a/Earthfile
+++ b/Earthfile
@@ -47,6 +47,9 @@ check:
   BUILD +test
   BUILD +fmt
 
+  # DEBUG which tags are available?
+  RUN git tag --list
+
 # bumps the version of the plugin if impactful commits have been made
 bumpVersion:
   ARG COMMITTER_NAME

--- a/Earthfile
+++ b/Earthfile
@@ -104,7 +104,7 @@ COPY_GIT:
   FUNCTION
 
   COPY --keep-ts --dir .git ./
-  RUN git pull --tags
+  RUN git fetch --tags
 
 COPY_SOURCE:
   FUNCTION


### PR DESCRIPTION
Even though there is a v0.1.0 tag in the repository, it isn't being picked up on by the `bumpVersion` target.