### PR TITLE
Refactor tests

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -3,10 +3,6 @@ use crate::utils::process_pipeline;
 use crate::VecPlugin;
 use itertools::Itertools;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-#[cfg(test)]
-use nu_plugin_test_support::PluginTest;
-#[cfg(test)]
-use nu_protocol::ShellError;
 use nu_protocol::{
     Category, Example, IntoValue, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type,
     Value,
@@ -122,10 +118,4 @@ pub fn sum_vectors(
     let output = output_values.into_value(command_span);
 
     Ok(output)
-}
-
-#[cfg(test)]
-#[test]
-fn test_examples() -> Result<(), ShellError> {
-    PluginTest::new("nu_plugin_vec", VecPlugin.into())?.test_command_examples(&Command)
 }

--- a/src/commands/cos.rs
+++ b/src/commands/cos.rs
@@ -5,10 +5,6 @@ use crate::utils::process_pipeline;
 use crate::VecPlugin;
 use itertools::Itertools;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-#[cfg(test)]
-use nu_plugin_test_support::PluginTest;
-#[cfg(test)]
-use nu_protocol::ShellError;
 use nu_protocol::{
     Category, Example, IntoValue, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type,
     Value,
@@ -119,10 +115,4 @@ pub fn compute_vcos(
     let output = dot_product.div(command_span, &magnitude_product, command_span);
 
     output.map_err(LabeledError::from)
-}
-
-#[cfg(test)]
-#[test]
-fn test_examples() -> Result<(), ShellError> {
-    PluginTest::new("nu_plugin_vec", VecPlugin.into())?.test_command_examples(&Command)
 }

--- a/src/commands/dot.rs
+++ b/src/commands/dot.rs
@@ -5,10 +5,6 @@ use crate::utils::reducers::sum;
 use crate::VecPlugin;
 use itertools::Itertools;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-#[cfg(test)]
-use nu_plugin_test_support::PluginTest;
-#[cfg(test)]
-use nu_protocol::ShellError;
 use nu_protocol::{
     Category, Example, IntoValue, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type,
     Value,
@@ -118,10 +114,4 @@ pub fn compute_dot_product(
             .to_vec();
 
     sum(element_products, pipeline_span, command_span)
-}
-
-#[cfg(test)]
-#[test]
-fn test_examples() -> Result<(), ShellError> {
-    PluginTest::new("nu_plugin_vec", VecPlugin.into())?.test_command_examples(&Command)
 }

--- a/src/commands/magnitude.rs
+++ b/src/commands/magnitude.rs
@@ -2,10 +2,6 @@ use crate::commands::sqnorm::compute_squared_norm;
 use crate::utils::process_pipeline;
 use crate::VecPlugin;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-#[cfg(test)]
-use nu_plugin_test_support::PluginTest;
-#[cfg(test)]
-use nu_protocol::ShellError;
 use nu_protocol::{
     Category, Example, IntoValue, LabeledError, PipelineData, Signature, Span, Type, Value,
 };
@@ -75,10 +71,4 @@ pub fn compute_magnitude(
         .map(|float| float.sqrt().into_value(command_span));
 
     output.map_err(LabeledError::from)
-}
-
-#[cfg(test)]
-#[test]
-fn test_examples() -> Result<(), ShellError> {
-    PluginTest::new("nu_plugin_vec", VecPlugin.into())?.test_command_examples(&Command)
 }

--- a/src/commands/normalize.rs
+++ b/src/commands/normalize.rs
@@ -3,10 +3,6 @@ use crate::utils::process_pipeline;
 use crate::VecPlugin;
 use itertools::Itertools;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-#[cfg(test)]
-use nu_plugin_test_support::PluginTest;
-#[cfg(test)]
-use nu_protocol::ShellError;
 use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Span, Type, Value};
 
 #[derive(Clone)]
@@ -85,10 +81,4 @@ pub fn normalize_vector(
     );
 
     Ok(output)
-}
-
-#[cfg(test)]
-#[test]
-fn test_examples() -> Result<(), ShellError> {
-    PluginTest::new("nu_plugin_vec", VecPlugin.into())?.test_command_examples(&Command)
 }

--- a/src/commands/sin.rs
+++ b/src/commands/sin.rs
@@ -4,10 +4,6 @@ use crate::utils::process_pipeline;
 use crate::VecPlugin;
 use itertools::Itertools;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-#[cfg(test)]
-use nu_plugin_test_support::PluginTest;
-#[cfg(test)]
-use nu_protocol::ShellError;
 use nu_protocol::{
     Category, Example, IntoValue, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type,
     Value,
@@ -114,10 +110,4 @@ pub fn compute_vsin(
         .map(|float| float.sqrt().into_value(command_span));
 
     output.map_err(LabeledError::from)
-}
-
-#[cfg(test)]
-#[test]
-fn test_examples() -> Result<(), ShellError> {
-    PluginTest::new("nu_plugin_vec", VecPlugin.into())?.test_command_examples(&Command)
 }

--- a/src/commands/sqnorm.rs
+++ b/src/commands/sqnorm.rs
@@ -2,10 +2,6 @@ use crate::commands::dot::compute_dot_product;
 use crate::utils::process_pipeline;
 use crate::VecPlugin;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-#[cfg(test)]
-use nu_plugin_test_support::PluginTest;
-#[cfg(test)]
-use nu_protocol::ShellError;
 use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Span, Type, Value};
 
 #[derive(Clone)]
@@ -64,10 +60,4 @@ pub fn compute_squared_norm(
     command_span: Span,
 ) -> Result<Value, LabeledError> {
     compute_dot_product(vector, vector, pipeline_span, command_span)
-}
-
-#[cfg(test)]
-#[test]
-fn test_examples() -> Result<(), ShellError> {
-    PluginTest::new("nu_plugin_vec", VecPlugin.into())?.test_command_examples(&Command)
 }

--- a/src/commands/sub.rs
+++ b/src/commands/sub.rs
@@ -3,10 +3,6 @@ use crate::utils::process_pipeline;
 use crate::VecPlugin;
 use itertools::Itertools;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-#[cfg(test)]
-use nu_plugin_test_support::PluginTest;
-#[cfg(test)]
-use nu_protocol::ShellError;
 use nu_protocol::{
     Category, Example, IntoValue, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type,
     Value,
@@ -122,10 +118,4 @@ pub fn subtract_vectors(
     let output = output_values.into_value(command_span);
 
     Ok(output)
-}
-
-#[cfg(test)]
-#[test]
-fn test_examples() -> Result<(), ShellError> {
-    PluginTest::new("nu_plugin_vec", VecPlugin.into())?.test_command_examples(&Command)
 }

--- a/tests/commands/add.rs
+++ b/tests/commands/add.rs
@@ -1,0 +1,6 @@
+use nu_plugin_test_support::PluginTest;
+use nu_plugin_vec::commands::Add as Command;
+use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_protocol::ShellError;
+
+test_examples!();

--- a/tests/commands/add.rs
+++ b/tests/commands/add.rs
@@ -1,6 +1,28 @@
 use nu_plugin_test_support::PluginTest;
 use nu_plugin_vec::commands::Add as Command;
-use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_plugin_vec::{nu, test_examples, VecPlugin};
 use nu_protocol::ShellError;
 
 test_examples!();
+
+#[test]
+fn errors_when_left_vector_is_shorter() {
+    let result = nu!("\
+                let a = [1 2];\
+                let b = [1 2 3 4 5];\
+                \
+                $a | vec add $b");
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn errors_when_right_vector_is_shorter() {
+    let result = nu!("\
+                let a = [1 2 3 4 5];\
+                let b = [1 2 3];\
+                \
+                $a | vec add $b");
+
+    assert!(result.is_err());
+}

--- a/tests/commands/cos.rs
+++ b/tests/commands/cos.rs
@@ -1,6 +1,28 @@
 use nu_plugin_test_support::PluginTest;
 use nu_plugin_vec::commands::Cosine as Command;
-use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_plugin_vec::{nu, test_examples, VecPlugin};
 use nu_protocol::ShellError;
 
 test_examples!();
+
+#[test]
+fn errors_when_left_vector_is_shorter() {
+    let result = nu!("\
+                let a = [1 2];\
+                let b = [1 2 3 4 5];\
+                \
+                $a | vec cos $b");
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn errors_when_right_vector_is_shorter() {
+    let result = nu!("\
+                let a = [1 2 3 4 5];\
+                let b = [1 2 3];\
+                \
+                $a | vec cos $b");
+
+    assert!(result.is_err());
+}

--- a/tests/commands/cos.rs
+++ b/tests/commands/cos.rs
@@ -1,0 +1,6 @@
+use nu_plugin_test_support::PluginTest;
+use nu_plugin_vec::commands::Cosine as Command;
+use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_protocol::ShellError;
+
+test_examples!();

--- a/tests/commands/dot.rs
+++ b/tests/commands/dot.rs
@@ -1,0 +1,6 @@
+use nu_plugin_test_support::PluginTest;
+use nu_plugin_vec::commands::Dot as Command;
+use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_protocol::ShellError;
+
+test_examples!();

--- a/tests/commands/dot.rs
+++ b/tests/commands/dot.rs
@@ -1,6 +1,28 @@
 use nu_plugin_test_support::PluginTest;
 use nu_plugin_vec::commands::Dot as Command;
-use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_plugin_vec::{nu, test_examples, VecPlugin};
 use nu_protocol::ShellError;
 
 test_examples!();
+
+#[test]
+fn errors_when_left_vector_is_shorter() {
+    let result = nu!("\
+                let a = [1 2];\
+                let b = [1 2 3 4 5];\
+                \
+                $a | vec dot $b");
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn errors_when_right_vector_is_shorter() {
+    let result = nu!("\
+                let a = [1 2 3 4 5];\
+                let b = [1 2 3];\
+                \
+                $a | vec dot $b");
+
+    assert!(result.is_err());
+}

--- a/tests/commands/magnitude.rs
+++ b/tests/commands/magnitude.rs
@@ -1,0 +1,6 @@
+use nu_plugin_test_support::PluginTest;
+use nu_plugin_vec::commands::Magnitude as Command;
+use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_protocol::ShellError;
+
+test_examples!();

--- a/tests/commands/mod.rs
+++ b/tests/commands/mod.rs
@@ -1,1 +1,9 @@
 mod scale;
+mod add;
+mod cos;
+mod dot;
+mod magnitude;
+mod normalize;
+mod sin;
+mod sqnorm;
+mod sub;

--- a/tests/commands/normalize.rs
+++ b/tests/commands/normalize.rs
@@ -1,0 +1,6 @@
+use nu_plugin_test_support::PluginTest;
+use nu_plugin_vec::commands::Normalize as Command;
+use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_protocol::ShellError;
+
+test_examples!();

--- a/tests/commands/scale.rs
+++ b/tests/commands/scale.rs
@@ -1,14 +1,13 @@
 use nu_plugin_test_support::PluginTest;
 use nu_plugin_vec::commands::Scale as Command;
-use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_plugin_vec::{nu, test_examples, VecPlugin};
 use nu_protocol::ShellError;
 
 test_examples!();
 
 mod scale_vector_stretching {
+    use super::*;
     use itertools::Itertools;
-    use nu_plugin_test_support::PluginTest;
-    use nu_plugin_vec::{nu, VecPlugin};
 
     #[test]
     fn errors_when_factor_vector_is_shorter() {
@@ -49,9 +48,8 @@ mod scale_vector_stretching {
 }
 
 mod scale_vector_uniform {
+    use super::*;
     use itertools::Itertools;
-    use nu_plugin_test_support::PluginTest;
-    use nu_plugin_vec::{nu, VecPlugin};
 
     #[test]
     fn keeps_ints_where_possible_when_using_int_factor() {

--- a/tests/commands/sin.rs
+++ b/tests/commands/sin.rs
@@ -1,6 +1,28 @@
 use nu_plugin_test_support::PluginTest;
 use nu_plugin_vec::commands::Sine as Command;
-use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_plugin_vec::{nu, test_examples, VecPlugin};
 use nu_protocol::ShellError;
 
 test_examples!();
+
+#[test]
+fn errors_when_left_vector_is_shorter() {
+    let result = nu!("\
+                let a = [1 2];\
+                let b = [1 2 3 4 5];\
+                \
+                $a | vec sin $b");
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn errors_when_right_vector_is_shorter() {
+    let result = nu!("\
+                let a = [1 2 3 4 5];\
+                let b = [1 2 3];\
+                \
+                $a | vec sin $b");
+
+    assert!(result.is_err());
+}

--- a/tests/commands/sin.rs
+++ b/tests/commands/sin.rs
@@ -1,0 +1,6 @@
+use nu_plugin_test_support::PluginTest;
+use nu_plugin_vec::commands::Sine as Command;
+use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_protocol::ShellError;
+
+test_examples!();

--- a/tests/commands/sqnorm.rs
+++ b/tests/commands/sqnorm.rs
@@ -1,0 +1,6 @@
+use nu_plugin_test_support::PluginTest;
+use nu_plugin_vec::commands::SqNorm as Command;
+use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_protocol::ShellError;
+
+test_examples!();

--- a/tests/commands/sub.rs
+++ b/tests/commands/sub.rs
@@ -1,0 +1,6 @@
+use nu_plugin_test_support::PluginTest;
+use nu_plugin_vec::commands::Sub as Command;
+use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_protocol::ShellError;
+
+test_examples!();

--- a/tests/commands/sub.rs
+++ b/tests/commands/sub.rs
@@ -1,6 +1,28 @@
 use nu_plugin_test_support::PluginTest;
 use nu_plugin_vec::commands::Sub as Command;
-use nu_plugin_vec::{test_examples, VecPlugin};
+use nu_plugin_vec::{nu, test_examples, VecPlugin};
 use nu_protocol::ShellError;
 
 test_examples!();
+
+#[test]
+fn errors_when_left_vector_is_shorter() {
+    let result = nu!("\
+                let a = [1 2];\
+                let b = [1 2 3 4 5];\
+                \
+                $a | vec sub $b");
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn errors_when_right_vector_is_shorter() {
+    let result = nu!("\
+                let a = [1 2 3 4 5];\
+                let b = [1 2 3];\
+                \
+                $a | vec sub $b");
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
This PR moves tests to be integration tests, as they use a new `nu!` macro, which executes code as if it were a Nushell script.