### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Dennis Kottier <inquiries@photonbur.st>"]
 description = "A Nushell plugin implementing vector operations"
 edition = "2021"
-homepage = "https://github.com/PhotonBursted/nu_plugin_vec"
+repository = "https://github.com/PhotonBursted/nu_plugin_vec"
 license = "MIT"
 name = "nu_plugin_vec"
 readme = "README.md"


### PR DESCRIPTION
According to the [manifset](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/91